### PR TITLE
Support for networks with multiple backend servers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile 'net.md-5:bungeecord-api:1.12-SNAPSHOT'
+    compile 'net.md-5:bungeecord-api:1.15-SNAPSHOT'
     implementation 'com.github.EmotionalLove:SimpleSettingSystem:e2aaa43f25'
     implementation 'com.github.EmotionalLove:QuickYML:6cb1f648f004f6a29b7cf5ca1c071e67d8a3d7ea'
 }

--- a/src/main/java/me/someonelove/matsuqueue/bungee/ConfigurationFile.java
+++ b/src/main/java/me/someonelove/matsuqueue/bungee/ConfigurationFile.java
@@ -18,7 +18,7 @@ import java.util.logging.Level;
  */
 public class ConfigurationFile {
 
-    public static final String FILE_NAME = "QueueConfig.yml";
+    public static final String FILE_NAME = "plugins/MatsuQueue/config.yml";
 
     public String queueServerKey;
     public String destinationServerKey;

--- a/src/main/java/me/someonelove/matsuqueue/bungee/EventReactions.java
+++ b/src/main/java/me/someonelove/matsuqueue/bungee/EventReactions.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.PreLoginEvent;
 import net.md_5.bungee.api.event.ServerConnectedEvent;
+import net.md_5.bungee.api.event.ServerSwitchEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 
@@ -117,5 +118,25 @@ public class EventReactions implements Listener {
         }
         IMatsuSlotCluster slots = Matsu.CONFIG.slotsMap.get(Matsu.slotPermissionCache.get("matsuqueue.default."));
         slots.queuePlayer(p);
+    }
+    
+    @EventHandler
+    public void onServerChange(ServerSwitchEvent e) {
+    	if (e.getFrom() != null ) {
+    		if (e.getFrom().getName().equals(Matsu.CONFIG.destinationServerKey)) {
+        		Matsu.CONFIG.slotsMap.forEach((name, slot) -> {
+                    slot.onPlayerLeave(e.getPlayer());
+                });
+        	}
+        	else if (e.getFrom().getName().equals(Matsu.CONFIG.queueServerKey) && !e.getPlayer().getServer().getInfo().getName().equals(Matsu.CONFIG.destinationServerKey)) {
+        		Matsu.CONFIG.slotsMap.forEach((str, cluster) -> {
+            		cluster.getAssociatedQueues().forEach((name, queue) -> {
+            			if (queue.getQueue().contains(e.getPlayer().getUniqueId())) {
+            				queue.removePlayerFromQueue(e.getPlayer());
+            			}
+            		});
+            	});
+        	}
+    	}
     }
 }


### PR DESCRIPTION
This needs to be built against Bungeecord's 1.15 API, so will need an up-to-date version of bungeecord to run.

I've added a ServerSwitchEvent handler which will remove a player from the queue they are in or from the slot they're taking up if they use /server to change server. This feature is intended for bungeecord networks with more servers than just the destination and queue server. Since forced hosts can't be used with this plugin at the moment, using /server is the only way to change servers.

I also added the purgeQueues method (original method was renamed to purgeSlots) which has the same functionality as purgeSlots, but for each queue. This should clean up any players changing from the queue server that weren't handled for whatever reason. I also modified the condition that determines if a UUID is to be added to the removalList to add players who had changed server using /server but not disconnected, to the list.

Also moved the config from the root into 'plugins/MastuQueue/config.yml'.

In my experience, the new purgeQueues method being run periodically along with purgeSlots has resolved https://github.com/EmotionalLove/MatsuQueueBungee/issues/8 and resolved https://github.com/EmotionalLove/MatsuQueueBungee/issues/11 for me, although not sure if it will for the original users.